### PR TITLE
chore: remove environment

### DIFF
--- a/.github/workflows/gem-workflow.yaml
+++ b/.github/workflows/gem-workflow.yaml
@@ -18,7 +18,6 @@ jobs:
           bundler-cache: true
       - run: bundle exec rubocop
   rspec:
-    environment: test
     strategy:
       matrix:
         ruby-version: [2.6.3, 2.6.6, 2.7.1]


### PR DESCRIPTION
Why
-  To remove environment from ci (redundant)

How
- Modified git hub actions yaml file
